### PR TITLE
feat(ui): implement Modern Game Manager layout with functional stubs

### DIFF
--- a/rpcs3/Emu/GUI/modern/ModernLibraryModel.cpp
+++ b/rpcs3/Emu/GUI/modern/ModernLibraryModel.cpp
@@ -1,22 +1,122 @@
 #include "ModernLibraryModel.h"
 
+#include "Emu/System.h"
+#include "Emu/system_utils.hpp"
+#include "Loader/PSF.h"
+#include "Utilities/File.h"
+#include "util/logs.hpp"
+
+LOG_CHANNEL(modern_library_log, "ModernLibrary");
+
 namespace rpcs3::ui
 {
-	ModernLibraryModel::ModernLibraryModel(QObject* parent)
-		: QAbstractListModel(parent)
-	{
-	}
+       ModernLibraryModel::ModernLibraryModel(QObject* parent)
+               : QAbstractListModel(parent)
+       {
+               refresh();
+       }
 
-	int ModernLibraryModel::rowCount(const QModelIndex& parent) const
-	{
-		Q_UNUSED(parent);
-		return 0;
-	}
+       int ModernLibraryModel::rowCount(const QModelIndex& parent) const
+       {
+               Q_UNUSED(parent);
+               return static_cast<int>(m_filtered_indexes.size());
+       }
 
-	QVariant ModernLibraryModel::data(const QModelIndex& index, int role) const
-	{
-		Q_UNUSED(index);
-		Q_UNUSED(role);
-		return {};
-	}
+       QVariant ModernLibraryModel::data(const QModelIndex& index, int role) const
+       {
+               if (!index.isValid() || index.row() < 0 || index.row() >= rowCount())
+               {
+                       return {};
+               }
+
+               const GameEntry& entry = m_games[m_filtered_indexes[index.row()]];
+
+               switch (role)
+               {
+               case Qt::DisplayRole:
+                       return entry.name;
+               case Qt::DecorationRole:
+                       return entry.icon;
+               default:
+                       return {};
+               }
+       }
+
+       void ModernLibraryModel::setFilterString(const QString& filter)
+       {
+               if (m_filter == filter)
+               {
+                       return;
+               }
+
+               m_filter = filter;
+               beginResetModel();
+               applyFilter();
+               endResetModel();
+       }
+
+       ModernLibraryModel::GameEntry ModernLibraryModel::entryAt(const QModelIndex& index) const
+       {
+               if (!index.isValid() || index.row() < 0 || index.row() >= rowCount())
+               {
+                       return {};
+               }
+
+               return m_games[m_filtered_indexes[index.row()]];
+       }
+
+       void ModernLibraryModel::refresh()
+       {
+               beginResetModel();
+               m_games.clear();
+
+               const auto game_map = Emu.GetGamesConfig().get_games();
+
+               for (const auto& [title_id, path] : game_map)
+               {
+                       GameEntry entry;
+                       entry.title_id = QString::fromStdString(title_id);
+                       entry.path = QString::fromStdString(path);
+
+                       const std::string sfo_dir = rpcs3::utils::get_sfo_dir_from_game_path(path, title_id);
+                       const std::string sfo_path = sfo_dir + "/PARAM.SFO";
+                       const psf::registry psf = psf::load_object(sfo_path);
+
+                       std::string name = std::string(psf::get_string(psf, "TITLE"));
+                       if (name.empty())
+                       {
+                               name = title_id;
+                       }
+                       entry.name = QString::fromStdString(name);
+
+                       const QString icon_path = QString::fromStdString(sfo_dir + "/ICON0.PNG");
+                       if (QFile::exists(icon_path))
+                       {
+                               entry.icon = QPixmap(icon_path);
+                       }
+
+                       entry.status = tr("Unknown");
+                       entry.last_played = tr("Never");
+                       entry.hours_played = 0;
+
+                       m_games.emplace_back(std::move(entry));
+               }
+
+               applyFilter();
+               endResetModel();
+       }
+
+       void ModernLibraryModel::applyFilter()
+       {
+               m_filtered_indexes.clear();
+
+               for (int i = 0; i < static_cast<int>(m_games.size()); ++i)
+               {
+                       const auto& g = m_games[i];
+                       if (m_filter.isEmpty() || g.name.contains(m_filter, Qt::CaseInsensitive) || g.title_id.contains(m_filter, Qt::CaseInsensitive))
+                       {
+                               m_filtered_indexes.push_back(i);
+                       }
+               }
+       }
 } // namespace rpcs3::ui

--- a/rpcs3/Emu/GUI/modern/ModernLibraryModel.h
+++ b/rpcs3/Emu/GUI/modern/ModernLibraryModel.h
@@ -1,17 +1,43 @@
 #pragma once
 
 #include <QAbstractListModel>
+#include <QPixmap>
+#include <vector>
+
+struct GameInfo; // forward decl if needed? But we will use psf not GameInfo. but not needed
 
 namespace rpcs3::ui
 {
-	class ModernLibraryModel : public QAbstractListModel
-	{
-		Q_OBJECT
+       class ModernLibraryModel : public QAbstractListModel
+       {
+               Q_OBJECT
 
-	public:
-		explicit ModernLibraryModel(QObject* parent = nullptr);
+       public:
+               struct GameEntry
+               {
+                       QString title_id;
+                       QString name;
+                       QString path;
+                       QPixmap icon;
+                       QString status;
+                       QString last_played;
+                       quint64 hours_played = 0;
+               };
 
-		int rowCount(const QModelIndex& parent = QModelIndex()) const override;
-		QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
-	};
+               explicit ModernLibraryModel(QObject* parent = nullptr);
+
+               int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+               QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+
+               void setFilterString(const QString& filter);
+               GameEntry entryAt(const QModelIndex& index) const;
+               void refresh();
+
+       private:
+               void applyFilter();
+
+               QString m_filter;
+               std::vector<GameEntry> m_games;
+               std::vector<int> m_filtered_indexes;
+       };
 } // namespace rpcs3::ui

--- a/rpcs3/Emu/GUI/modern/ModernManagerWindow.cpp
+++ b/rpcs3/Emu/GUI/modern/ModernManagerWindow.cpp
@@ -1,11 +1,162 @@
 #include "ModernManagerWindow.h"
 
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QFileDialog>
+#include <QItemSelectionModel>
+#include <memory>
+
+#include "Emu/System.h"
+#include "util/logs.hpp"
+#include "rpcs3qt/pad_settings_dialog.h"
+#include "rpcs3qt/gui_settings.h"
+
+LOG_CHANNEL(modern_manager_log, "ModernManager");
+
 namespace rpcs3::ui
 {
-	ModernManagerWindow::ModernManagerWindow(QWidget* parent)
-		: QMainWindow(parent)
-	{
-	}
+       ModernManagerWindow::ModernManagerWindow(QWidget* parent)
+               : QMainWindow(parent)
+       {
+               searchBar = new QLineEdit(this);
+               btnSettings = new QPushButton(tr("Settings"), this);
+               lblFirmwareStatus = new QLabel(tr("FW Unknown"), this);
 
-	ModernManagerWindow::~ModernManagerWindow() = default;
+               btnAddGame = new QPushButton(tr("Add Game"), this);
+               btnOptimize = new QPushButton(tr("Optimize"), this);
+               btnPrebuildShaders = new QPushButton(tr("Prebuild Shaders"), this);
+               btnControllerSetup = new QPushButton(tr("Controller Setup"), this);
+               btnUpdateAll = new QPushButton(tr("Update All"), this);
+
+               gameGrid = new QListView(this);
+               gameGrid->setViewMode(QListView::IconMode);
+               gameGrid->setWrapping(true);
+               gameGrid->setResizeMode(QListView::Adjust);
+
+               lblGameTitle = new QLabel(this);
+               lblLastPlayed = new QLabel(this);
+               lblHoursPlayed = new QLabel(this);
+               lblStatus = new QLabel(this);
+               btnPlay = new QPushButton(tr("Play"), this);
+
+               m_model = new ModernLibraryModel(this);
+               gameGrid->setModel(m_model);
+
+               auto* central = new QWidget(this);
+               auto* mainLayout = new QVBoxLayout(central);
+
+               auto* topLayout = new QHBoxLayout();
+               topLayout->addWidget(searchBar);
+               topLayout->addWidget(btnSettings);
+               topLayout->addWidget(lblFirmwareStatus);
+               mainLayout->addLayout(topLayout);
+
+               auto* toolbarLayout = new QHBoxLayout();
+               toolbarLayout->addWidget(btnAddGame);
+               toolbarLayout->addWidget(btnOptimize);
+               toolbarLayout->addWidget(btnPrebuildShaders);
+               toolbarLayout->addWidget(btnControllerSetup);
+               toolbarLayout->addWidget(btnUpdateAll);
+               mainLayout->addLayout(toolbarLayout);
+
+               mainLayout->addWidget(gameGrid);
+
+               auto* detailsLayout = new QHBoxLayout();
+               auto* infoLayout = new QVBoxLayout();
+               infoLayout->addWidget(lblGameTitle);
+               infoLayout->addWidget(lblLastPlayed);
+               infoLayout->addWidget(lblHoursPlayed);
+               infoLayout->addWidget(lblStatus);
+               detailsLayout->addLayout(infoLayout);
+               detailsLayout->addStretch();
+               detailsLayout->addWidget(btnPlay);
+               mainLayout->addLayout(detailsLayout);
+
+               setCentralWidget(central);
+
+               connect(searchBar, &QLineEdit::textChanged, m_model, &ModernLibraryModel::setFilterString);
+               connect(btnAddGame, &QPushButton::clicked, this, &ModernManagerWindow::slotAddGame);
+               connect(btnOptimize, &QPushButton::clicked, this, &ModernManagerWindow::slotOptimize);
+               connect(btnPrebuildShaders, &QPushButton::clicked, this, &ModernManagerWindow::slotPrebuildShaders);
+               connect(btnControllerSetup, &QPushButton::clicked, this, &ModernManagerWindow::slotControllerSetup);
+               connect(btnUpdateAll, &QPushButton::clicked, this, &ModernManagerWindow::slotUpdateAll);
+               connect(gameGrid->selectionModel(), &QItemSelectionModel::selectionChanged, this, &ModernManagerWindow::updateDetailsPane);
+               connect(btnPlay, &QPushButton::clicked, this, &ModernManagerWindow::slotPlayGame);
+       }
+
+       ModernManagerWindow::~ModernManagerWindow() = default;
+
+       ModernLibraryModel::GameEntry ModernManagerWindow::currentEntry() const
+       {
+               return m_model->entryAt(gameGrid->currentIndex());
+       }
+
+       void ModernManagerWindow::slotAddGame()
+       {
+               const QString dir = QFileDialog::getExistingDirectory(this, tr("Select Game Folder"));
+               if (dir.isEmpty())
+               {
+                       return;
+               }
+
+               if (Emu.AddGamesFromDir(dir.toStdString()) > 0)
+               {
+                       m_model->refresh();
+               }
+       }
+
+       void ModernManagerWindow::slotOptimize()
+       {
+               const auto entry = currentEntry();
+               if (!entry.title_id.isEmpty())
+               {
+                       modern_manager_log.notice("Optimize requested for %s", entry.title_id.toStdString());
+               }
+       }
+
+       void ModernManagerWindow::slotPrebuildShaders()
+       {
+               const auto entry = currentEntry();
+               if (!entry.title_id.isEmpty())
+               {
+                       modern_manager_log.notice("Prebuild shaders requested for %s", entry.title_id.toStdString());
+               }
+       }
+
+       void ModernManagerWindow::slotControllerSetup()
+       {
+               auto settings = std::make_shared<gui_settings>();
+               pad_settings_dialog dlg(settings, this);
+               dlg.exec();
+       }
+
+       void ModernManagerWindow::slotUpdateAll()
+       {
+               modern_manager_log.notice("Update all requested");
+               m_model->refresh();
+       }
+
+       void ModernManagerWindow::slotPlayGame()
+       {
+               const auto entry = currentEntry();
+               if (entry.path.isEmpty())
+               {
+                       return;
+               }
+
+               const auto res = Emu.BootGame(entry.path.toStdString(), entry.title_id.toStdString(), true);
+               if (res != game_boot_result::no_errors)
+               {
+                       modern_manager_log.error("Failed to boot %s", entry.title_id.toStdString());
+               }
+       }
+
+       void ModernManagerWindow::updateDetailsPane()
+       {
+               const auto entry = currentEntry();
+               lblGameTitle->setText(entry.name);
+               lblLastPlayed->setText(entry.last_played);
+               lblHoursPlayed->setText(QString::number(entry.hours_played));
+               lblStatus->setText(entry.status);
+       }
 } // namespace rpcs3::ui

--- a/rpcs3/Emu/GUI/modern/ModernManagerWindow.h
+++ b/rpcs3/Emu/GUI/modern/ModernManagerWindow.h
@@ -1,15 +1,50 @@
 #pragma once
 
 #include <QMainWindow>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QLabel>
+#include <QListView>
+
+#include "ModernLibraryModel.h"
 
 namespace rpcs3::ui
 {
-	class ModernManagerWindow : public QMainWindow
-	{
-		Q_OBJECT
+       class ModernManagerWindow : public QMainWindow
+       {
+               Q_OBJECT
 
-	public:
-		explicit ModernManagerWindow(QWidget* parent = nullptr);
-		~ModernManagerWindow() override;
-	};
+       public:
+               explicit ModernManagerWindow(QWidget* parent = nullptr);
+               ~ModernManagerWindow() override;
+
+       private Q_SLOTS:
+               void slotAddGame();
+               void slotOptimize();
+               void slotPrebuildShaders();
+               void slotControllerSetup();
+               void slotUpdateAll();
+               void slotPlayGame();
+               void updateDetailsPane();
+
+       private:
+               ModernLibraryModel::GameEntry currentEntry() const;
+
+               ModernLibraryModel* m_model = nullptr;
+
+               QLineEdit* searchBar = nullptr;
+               QPushButton* btnSettings = nullptr;
+               QLabel* lblFirmwareStatus = nullptr;
+               QPushButton* btnAddGame = nullptr;
+               QPushButton* btnOptimize = nullptr;
+               QPushButton* btnPrebuildShaders = nullptr;
+               QPushButton* btnControllerSetup = nullptr;
+               QPushButton* btnUpdateAll = nullptr;
+               QListView* gameGrid = nullptr;
+               QLabel* lblGameTitle = nullptr;
+               QLabel* lblLastPlayed = nullptr;
+               QLabel* lblHoursPlayed = nullptr;
+               QLabel* lblStatus = nullptr;
+               QPushButton* btnPlay = nullptr;
+       };
 } // namespace rpcs3::ui


### PR DESCRIPTION
## Summary
- Add ModernManagerWindow with search, toolbar, game grid and details pane
- Connect UI actions to placeholder slots and basic game launching
- Introduce ModernLibraryModel with filtering and game data population

## Testing
- `cmake -S . -B build -DENABLE_MODERN_MANAGER=ON` *(fails: zstd/build/cmake not found; missing submodules)*


------