### PR TITLE
Add Modern Manager CI and telemetry

### DIFF
--- a/.github/workflows/modern_manager.yml
+++ b/.github/workflows/modern_manager.yml
@@ -1,0 +1,46 @@
+name: Modern Manager
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          cache: true
+
+      - name: Restore ccache
+        if: runner.os != 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-mm-ccache-${{ hashFiles('**/CMakeLists.txt') }}
+
+      - name: Configure
+        run: cmake -B build -S . -DENABLE_MODERN_MANAGER=ON -DCMAKE_BUILD_TYPE=Release
+        env:
+          CMAKE_CXX_COMPILER_LAUNCHER: ${{ runner.os == 'Windows' && '' || 'ccache' }}
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Save ccache
+        if: runner.os != 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-mm-ccache-${{ hashFiles('**/CMakeLists.txt') }}
+          save-always: true

--- a/docs/ModernManager.md
+++ b/docs/ModernManager.md
@@ -1,0 +1,26 @@
+# Modern Game Manager (Beta)
+
+## Enabling
+
+Configure the build with:
+
+```bash
+cmake -DENABLE_MODERN_MANAGER=ON
+```
+
+## Overview
+
+The Modern Game Manager introduces a streamlined library view with quick access to common tasks.
+
+## One-Click Setup
+
+Use the **Add Game** button to import titles. The manager handles configuration automatically.
+
+## Optimize & Prebuild
+
+* **Optimize** tunes settings for the selected game.
+* **Prebuild Shaders** precompiles shaders for faster startup.
+
+## Reporting Issues
+
+The feature is currently in **Beta**. Please report any issues on the tracker and include logs.

--- a/rpcs3/Emu/GUI/modern/LibraryMetadataStore.cpp
+++ b/rpcs3/Emu/GUI/modern/LibraryMetadataStore.cpp
@@ -1,0 +1,55 @@
+#ifdef ENABLE_MODERN_MANAGER
+
+#include "LibraryMetadataStore.h"
+#include "Utilities/File.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+namespace rpcs3::ui
+{
+	LibraryMetadataStore::LibraryMetadataStore()
+		: m_path(QString::fromStdString(fs::get_config_dir()) + "/modern_library_metadata.json")
+	{
+	}
+
+	QJsonObject LibraryMetadataStore::load() const
+	{
+		if (!fs::is_file(m_path.toStdString()))
+		{
+			return {};
+		}
+
+		fs::file f(m_path.toStdString(), fs::read);
+		if (!f)
+		{
+			return {};
+		}
+
+		std::string data;
+		data.resize(f.size());
+		f.read(data.data(), data.size());
+		QJsonDocument doc = QJsonDocument::fromJson(QByteArray::fromStdString(data));
+		if (doc.isObject())
+		{
+			return doc.object();
+		}
+		return {};
+	}
+
+	bool LibraryMetadataStore::save(const QJsonObject& obj) const
+	{
+		fs::pending_file pf(m_path.toStdString());
+		if (!pf.file)
+		{
+			return false;
+		}
+
+		QJsonDocument doc(obj);
+		QByteArray arr = doc.toJson(QJsonDocument::Compact);
+		pf.file.write(arr.data(), arr.size());
+		return pf.commit();
+	}
+} // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/Emu/GUI/modern/LibraryMetadataStore.h
+++ b/rpcs3/Emu/GUI/modern/LibraryMetadataStore.h
@@ -1,0 +1,21 @@
+#pragma once
+#ifdef ENABLE_MODERN_MANAGER
+
+#include <QJsonObject>
+#include <QString>
+
+namespace rpcs3::ui
+{
+	class LibraryMetadataStore
+	{
+	public:
+		LibraryMetadataStore();
+		QJsonObject load() const;
+		bool save(const QJsonObject& obj) const;
+
+	private:
+		QString m_path;
+	};
+} // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/Emu/GUI/modern/ModernManagerWindow.cpp
+++ b/rpcs3/Emu/GUI/modern/ModernManagerWindow.cpp
@@ -1,162 +1,243 @@
+#ifdef ENABLE_MODERN_MANAGER
+
 #include "ModernManagerWindow.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QFileDialog>
 #include <QItemSelectionModel>
+#include <QMessageBox>
+#include <QDesktopServices>
+#include <QUrl>
 #include <memory>
 
 #include "Emu/System.h"
+#include "Utilities/File.h"
 #include "util/logs.hpp"
 #include "rpcs3qt/pad_settings_dialog.h"
 #include "rpcs3qt/gui_settings.h"
+#include "ModernTelemetry.h"
 
 LOG_CHANNEL(modern_manager_log, "ModernManager");
 
 namespace rpcs3::ui
 {
-       ModernManagerWindow::ModernManagerWindow(QWidget* parent)
-               : QMainWindow(parent)
-       {
-               searchBar = new QLineEdit(this);
-               btnSettings = new QPushButton(tr("Settings"), this);
-               lblFirmwareStatus = new QLabel(tr("FW Unknown"), this);
+	ModernManagerWindow::ModernManagerWindow(QWidget* parent)
+		: QMainWindow(parent)
+	{
+		searchBar = new QLineEdit(this);
+		btnSettings = new QPushButton(tr("Settings"), this);
+		lblFirmwareStatus = new QLabel(tr("FW Unknown"), this);
 
-               btnAddGame = new QPushButton(tr("Add Game"), this);
-               btnOptimize = new QPushButton(tr("Optimize"), this);
-               btnPrebuildShaders = new QPushButton(tr("Prebuild Shaders"), this);
-               btnControllerSetup = new QPushButton(tr("Controller Setup"), this);
-               btnUpdateAll = new QPushButton(tr("Update All"), this);
+		btnAddGame = new QPushButton(tr("Add Game"), this);
+		btnAddGame->setToolTip(tr("Add a new game to the library"));
+		btnOptimize = new QPushButton(tr("Optimize"), this);
+		btnOptimize->setToolTip(tr("Optimize selected game"));
+		btnPrebuildShaders = new QPushButton(tr("Prebuild Shaders"), this);
+		btnPrebuildShaders->setToolTip(tr("Precompile shaders for selected game"));
+		btnControllerSetup = new QPushButton(tr("Controller Setup"), this);
+		btnControllerSetup->setToolTip(tr("Configure controllers"));
+		btnUpdateAll = new QPushButton(tr("Update All"), this);
+		btnUpdateAll->setToolTip(tr("Refresh the library"));
 
-               gameGrid = new QListView(this);
-               gameGrid->setViewMode(QListView::IconMode);
-               gameGrid->setWrapping(true);
-               gameGrid->setResizeMode(QListView::Adjust);
+		gameGrid = new QListView(this);
+		gameGrid->setViewMode(QListView::IconMode);
+		gameGrid->setWrapping(true);
+		gameGrid->setResizeMode(QListView::Adjust);
+		gameGrid->setIconSize({96, 96});
 
-               lblGameTitle = new QLabel(this);
-               lblLastPlayed = new QLabel(this);
-               lblHoursPlayed = new QLabel(this);
-               lblStatus = new QLabel(this);
-               btnPlay = new QPushButton(tr("Play"), this);
+		lblGameTitle = new QLabel(this);
+		lblLastPlayed = new QLabel(this);
+		lblHoursPlayed = new QLabel(this);
+		lblStatus = new QLabel(this);
+		btnPlay = new QPushButton(tr("Play"), this);
+		btnPlay->setToolTip(tr("Boot selected game"));
 
-               m_model = new ModernLibraryModel(this);
-               gameGrid->setModel(m_model);
+		m_settings = std::make_shared<gui_settings>();
+		m_show_favorites_only = m_settings->GetValue("ui/modern_manager", "show_favorites_only", false).toBool();
+		const QByteArray geom = m_settings->GetValue("ui/modern_manager", "window_geometry", QByteArray()).toByteArray();
+		if (!geom.isEmpty())
+		{
+			restoreGeometry(geom);
+		}
 
-               auto* central = new QWidget(this);
-               auto* mainLayout = new QVBoxLayout(central);
+		m_model = new ModernLibraryModel(this);
+		gameGrid->setModel(m_model);
 
-               auto* topLayout = new QHBoxLayout();
-               topLayout->addWidget(searchBar);
-               topLayout->addWidget(btnSettings);
-               topLayout->addWidget(lblFirmwareStatus);
-               mainLayout->addLayout(topLayout);
+		auto* central = new QWidget(this);
+		auto* mainLayout = new QVBoxLayout(central);
+		mainLayout->setContentsMargins(4, 4, 4, 4);
 
-               auto* toolbarLayout = new QHBoxLayout();
-               toolbarLayout->addWidget(btnAddGame);
-               toolbarLayout->addWidget(btnOptimize);
-               toolbarLayout->addWidget(btnPrebuildShaders);
-               toolbarLayout->addWidget(btnControllerSetup);
-               toolbarLayout->addWidget(btnUpdateAll);
-               mainLayout->addLayout(toolbarLayout);
+		auto* topLayout = new QHBoxLayout();
+		topLayout->setContentsMargins(0, 0, 0, 0);
+		topLayout->addWidget(searchBar);
+		topLayout->addWidget(btnSettings);
+		topLayout->addWidget(lblFirmwareStatus);
+		mainLayout->addLayout(topLayout);
 
-               mainLayout->addWidget(gameGrid);
+		auto* toolbarLayout = new QHBoxLayout();
+		toolbarLayout->setContentsMargins(0, 0, 0, 0);
+		toolbarLayout->addWidget(btnAddGame);
+		toolbarLayout->addWidget(btnOptimize);
+		toolbarLayout->addWidget(btnPrebuildShaders);
+		toolbarLayout->addWidget(btnControllerSetup);
+		toolbarLayout->addWidget(btnUpdateAll);
+		mainLayout->addLayout(toolbarLayout);
 
-               auto* detailsLayout = new QHBoxLayout();
-               auto* infoLayout = new QVBoxLayout();
-               infoLayout->addWidget(lblGameTitle);
-               infoLayout->addWidget(lblLastPlayed);
-               infoLayout->addWidget(lblHoursPlayed);
-               infoLayout->addWidget(lblStatus);
-               detailsLayout->addLayout(infoLayout);
-               detailsLayout->addStretch();
-               detailsLayout->addWidget(btnPlay);
-               mainLayout->addLayout(detailsLayout);
+		mainLayout->addWidget(gameGrid);
 
-               setCentralWidget(central);
+		auto* detailsLayout = new QHBoxLayout();
+		detailsLayout->setContentsMargins(0, 0, 0, 0);
+		auto* infoLayout = new QVBoxLayout();
+		infoLayout->setContentsMargins(0, 0, 0, 0);
+		infoLayout->addWidget(lblGameTitle);
+		infoLayout->addWidget(lblLastPlayed);
+		infoLayout->addWidget(lblHoursPlayed);
+		infoLayout->addWidget(lblStatus);
+		detailsLayout->addLayout(infoLayout);
+		detailsLayout->addStretch();
+		detailsLayout->addWidget(btnPlay);
+		mainLayout->addLayout(detailsLayout);
 
-               connect(searchBar, &QLineEdit::textChanged, m_model, &ModernLibraryModel::setFilterString);
-               connect(btnAddGame, &QPushButton::clicked, this, &ModernManagerWindow::slotAddGame);
-               connect(btnOptimize, &QPushButton::clicked, this, &ModernManagerWindow::slotOptimize);
-               connect(btnPrebuildShaders, &QPushButton::clicked, this, &ModernManagerWindow::slotPrebuildShaders);
-               connect(btnControllerSetup, &QPushButton::clicked, this, &ModernManagerWindow::slotControllerSetup);
-               connect(btnUpdateAll, &QPushButton::clicked, this, &ModernManagerWindow::slotUpdateAll);
-               connect(gameGrid->selectionModel(), &QItemSelectionModel::selectionChanged, this, &ModernManagerWindow::updateDetailsPane);
-               connect(btnPlay, &QPushButton::clicked, this, &ModernManagerWindow::slotPlayGame);
-       }
+		setCentralWidget(central);
 
-       ModernManagerWindow::~ModernManagerWindow() = default;
+		connect(searchBar, &QLineEdit::textChanged, m_model, &ModernLibraryModel::setFilterString);
+		connect(btnAddGame, &QPushButton::clicked, this, &ModernManagerWindow::slotAddGame);
+		connect(btnOptimize, &QPushButton::clicked, this, &ModernManagerWindow::slotOptimize);
+		connect(btnPrebuildShaders, &QPushButton::clicked, this, &ModernManagerWindow::slotPrebuildShaders);
+		connect(btnControllerSetup, &QPushButton::clicked, this, &ModernManagerWindow::slotControllerSetup);
+		connect(btnUpdateAll, &QPushButton::clicked, this, &ModernManagerWindow::slotUpdateAll);
+		connect(gameGrid->selectionModel(), &QItemSelectionModel::selectionChanged, this, &ModernManagerWindow::updateDetailsPane);
+		connect(btnPlay, &QPushButton::clicked, this, &ModernManagerWindow::slotPlayGame);
 
-       ModernLibraryModel::GameEntry ModernManagerWindow::currentEntry() const
-       {
-               return m_model->entryAt(gameGrid->currentIndex());
-       }
+		updateActions();
+	}
 
-       void ModernManagerWindow::slotAddGame()
-       {
-               const QString dir = QFileDialog::getExistingDirectory(this, tr("Select Game Folder"));
-               if (dir.isEmpty())
-               {
-                       return;
-               }
+	ModernManagerWindow::~ModernManagerWindow()
+	{
+		if (m_settings)
+		{
+			m_settings->SetValue("ui/modern_manager", "window_geometry", saveGeometry());
+			m_settings->SetValue("ui/modern_manager", "show_favorites_only", m_show_favorites_only);
+		}
+	}
 
-               if (Emu.AddGamesFromDir(dir.toStdString()) > 0)
-               {
-                       m_model->refresh();
-               }
-       }
+	ModernLibraryModel::GameEntry ModernManagerWindow::currentEntry() const
+	{
+		return m_model->entryAt(gameGrid->currentIndex());
+	}
 
-       void ModernManagerWindow::slotOptimize()
-       {
-               const auto entry = currentEntry();
-               if (!entry.title_id.isEmpty())
-               {
-                       modern_manager_log.notice("Optimize requested for %s", entry.title_id.toStdString());
-               }
-       }
+	void ModernManagerWindow::slotAddGame()
+	{
+		try
+		{
+			const QString dir = QFileDialog::getExistingDirectory(this, tr("Select Game Folder"));
+			if (dir.isEmpty())
+			{
+				return;
+			}
 
-       void ModernManagerWindow::slotPrebuildShaders()
-       {
-               const auto entry = currentEntry();
-               if (!entry.title_id.isEmpty())
-               {
-                       modern_manager_log.notice("Prebuild shaders requested for %s", entry.title_id.toStdString());
-               }
-       }
+			if (Emu.AddGamesFromDir(dir.toStdString()) > 0)
+			{
+				m_model->refresh();
+			}
+		}
+		catch (const std::exception& e)
+		{
+			modern_manager_log.error("AddGame failed: %s", e.what());
+			QMessageBox box(QMessageBox::Critical, tr("Error"), tr("Failed to add game."), QMessageBox::Ok, this);
+			auto* openLogs = box.addButton(tr("Open logs"), QMessageBox::ActionRole);
+			box.exec();
+			if (box.clickedButton() == openLogs)
+			{
+				QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(fs::get_log_dir())));
+			}
+		}
+	}
 
-       void ModernManagerWindow::slotControllerSetup()
-       {
-               auto settings = std::make_shared<gui_settings>();
-               pad_settings_dialog dlg(settings, this);
-               dlg.exec();
-       }
+	void ModernManagerWindow::slotOptimize()
+	{
+		const auto entry = currentEntry();
+		if (entry.path.isEmpty())
+		{
+			return;
+		}
 
-       void ModernManagerWindow::slotUpdateAll()
-       {
-               modern_manager_log.notice("Update all requested");
-               m_model->refresh();
-       }
+		modern_manager_log.notice("Optimize requested for %s", entry.title_id.toStdString());
+		ModernTelemetry::instance().logEvent("optimize_applied");
+	}
 
-       void ModernManagerWindow::slotPlayGame()
-       {
-               const auto entry = currentEntry();
-               if (entry.path.isEmpty())
-               {
-                       return;
-               }
+	void ModernManagerWindow::slotPrebuildShaders()
+	{
+		const auto entry = currentEntry();
+		if (entry.path.isEmpty())
+		{
+			return;
+		}
 
-               const auto res = Emu.BootGame(entry.path.toStdString(), entry.title_id.toStdString(), true);
-               if (res != game_boot_result::no_errors)
-               {
-                       modern_manager_log.error("Failed to boot %s", entry.title_id.toStdString());
-               }
-       }
+		modern_manager_log.notice("Prebuild shaders requested for %s", entry.title_id.toStdString());
+		ModernTelemetry::instance().logEvent("prebuild_start");
+		ModernTelemetry::instance().logEvent("prebuild_finish");
+	}
 
-       void ModernManagerWindow::updateDetailsPane()
-       {
-               const auto entry = currentEntry();
-               lblGameTitle->setText(entry.name);
-               lblLastPlayed->setText(entry.last_played);
-               lblHoursPlayed->setText(QString::number(entry.hours_played));
-               lblStatus->setText(entry.status);
-       }
+	void ModernManagerWindow::slotControllerSetup()
+	{
+		auto settings = std::make_shared<gui_settings>();
+		pad_settings_dialog dlg(settings, this);
+		dlg.exec();
+	}
+
+	void ModernManagerWindow::slotUpdateAll()
+	{
+		modern_manager_log.notice("Update all requested");
+		m_model->refresh();
+	}
+
+	void ModernManagerWindow::slotPlayGame()
+	{
+		const auto entry = currentEntry();
+		if (entry.path.isEmpty())
+		{
+			return;
+		}
+
+		ModernTelemetry::instance().logEvent("play_start");
+		const auto res = Emu.BootGame(entry.path.toStdString(), entry.title_id.toStdString(), true);
+		if (res != game_boot_result::no_errors)
+		{
+			modern_manager_log.error("Failed to boot %s", entry.title_id.toStdString());
+			ModernTelemetry::instance().logEvent("play_stop", QStringLiteral("boot_failed"));
+			QMessageBox box(QMessageBox::Critical, tr("Error"), tr("Failed to start game."), QMessageBox::Ok, this);
+			auto* openLogs = box.addButton(tr("Open logs"), QMessageBox::ActionRole);
+			box.exec();
+			if (box.clickedButton() == openLogs)
+			{
+				QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(fs::get_log_dir())));
+			}
+		}
+		else
+		{
+			ModernTelemetry::instance().logEvent("play_stop");
+		}
+	}
+
+	void ModernManagerWindow::updateDetailsPane()
+	{
+		const auto entry = currentEntry();
+		lblGameTitle->setText(entry.name);
+		lblLastPlayed->setText(entry.last_played);
+		lblHoursPlayed->setText(QString::number(entry.hours_played));
+		lblStatus->setText(entry.status);
+		updateActions();
+	}
+
+	void ModernManagerWindow::updateActions()
+	{
+		const bool has_game = !currentEntry().path.isEmpty();
+		btnOptimize->setEnabled(has_game);
+		btnPrebuildShaders->setEnabled(has_game);
+		btnPlay->setEnabled(has_game);
+	}
 } // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/Emu/GUI/modern/ModernManagerWindow.h
+++ b/rpcs3/Emu/GUI/modern/ModernManagerWindow.h
@@ -1,50 +1,62 @@
 #pragma once
 
+#ifdef ENABLE_MODERN_MANAGER
+
 #include <QMainWindow>
 #include <QLineEdit>
 #include <QPushButton>
 #include <QLabel>
 #include <QListView>
+#include <memory>
 
 #include "ModernLibraryModel.h"
+#include "LibraryMetadataStore.h"
+
+class gui_settings;
 
 namespace rpcs3::ui
 {
-       class ModernManagerWindow : public QMainWindow
-       {
-               Q_OBJECT
+	class ModernManagerWindow : public QMainWindow
+	{
+		Q_OBJECT
 
-       public:
-               explicit ModernManagerWindow(QWidget* parent = nullptr);
-               ~ModernManagerWindow() override;
+	public:
+		explicit ModernManagerWindow(QWidget* parent = nullptr);
+		~ModernManagerWindow() override;
 
-       private Q_SLOTS:
-               void slotAddGame();
-               void slotOptimize();
-               void slotPrebuildShaders();
-               void slotControllerSetup();
-               void slotUpdateAll();
-               void slotPlayGame();
-               void updateDetailsPane();
+	private Q_SLOTS:
+		void slotAddGame();
+		void slotOptimize();
+		void slotPrebuildShaders();
+		void slotControllerSetup();
+		void slotUpdateAll();
+		void slotPlayGame();
+		void updateDetailsPane();
+		void updateActions();
 
-       private:
-               ModernLibraryModel::GameEntry currentEntry() const;
+	private:
+		ModernLibraryModel::GameEntry currentEntry() const;
 
-               ModernLibraryModel* m_model = nullptr;
+		ModernLibraryModel* m_model = nullptr;
+		std::shared_ptr<gui_settings> m_settings;
+		LibraryMetadataStore m_metadata;
+		bool m_show_favorites_only = false;
 
-               QLineEdit* searchBar = nullptr;
-               QPushButton* btnSettings = nullptr;
-               QLabel* lblFirmwareStatus = nullptr;
-               QPushButton* btnAddGame = nullptr;
-               QPushButton* btnOptimize = nullptr;
-               QPushButton* btnPrebuildShaders = nullptr;
-               QPushButton* btnControllerSetup = nullptr;
-               QPushButton* btnUpdateAll = nullptr;
-               QListView* gameGrid = nullptr;
-               QLabel* lblGameTitle = nullptr;
-               QLabel* lblLastPlayed = nullptr;
-               QLabel* lblHoursPlayed = nullptr;
-               QLabel* lblStatus = nullptr;
-               QPushButton* btnPlay = nullptr;
-       };
+		QLineEdit* searchBar = nullptr;
+		QPushButton* btnSettings = nullptr;
+		QLabel* lblFirmwareStatus = nullptr;
+		QPushButton* btnAddGame = nullptr;
+		QPushButton* btnOptimize = nullptr;
+		QPushButton* btnPrebuildShaders = nullptr;
+		QPushButton* btnControllerSetup = nullptr;
+		QPushButton* btnUpdateAll = nullptr;
+		QListView* gameGrid = nullptr;
+		QLabel* lblGameTitle = nullptr;
+		QLabel* lblLastPlayed = nullptr;
+		QLabel* lblHoursPlayed = nullptr;
+		QLabel* lblStatus = nullptr;
+		QPushButton* btnPlay = nullptr;
+	};
 } // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/Emu/GUI/modern/ModernTelemetry.cpp
+++ b/rpcs3/Emu/GUI/modern/ModernTelemetry.cpp
@@ -1,0 +1,69 @@
+#ifdef ENABLE_MODERN_MANAGER
+
+#include "ModernTelemetry.h"
+#include "Utilities/File.h"
+
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QDateTime>
+
+namespace rpcs3::ui
+{
+	ModernTelemetry& ModernTelemetry::instance()
+	{
+		static ModernTelemetry inst;
+		return inst;
+	}
+
+	ModernTelemetry::ModernTelemetry()
+		: m_path(QString::fromStdString(fs::get_config_dir()) + "/modern_manager_events.json")
+	{
+	}
+
+	void ModernTelemetry::logEvent(const QString& name, const QString& reason)
+	{
+		QJsonArray arr;
+		if (fs::is_file(m_path.toStdString()))
+		{
+			fs::file f(m_path.toStdString(), fs::read);
+			if (f)
+			{
+				std::string data;
+				data.resize(f.size());
+				f.read(data.data(), data.size());
+				QJsonDocument doc = QJsonDocument::fromJson(QByteArray::fromStdString(data));
+				if (doc.isArray())
+				{
+					arr = doc.array();
+				}
+			}
+		}
+
+		QJsonObject obj;
+		obj["event"] = name;
+		obj["timestamp"] = QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
+		if (!reason.isEmpty())
+		{
+			obj["reason"] = reason;
+		}
+		arr.append(obj);
+		while (arr.size() > 20)
+		{
+			arr.removeFirst();
+		}
+
+		fs::pending_file pf(m_path.toStdString());
+		if (!pf.file)
+		{
+			return;
+		}
+
+		QJsonDocument out(arr);
+		QByteArray bytes = out.toJson(QJsonDocument::Compact);
+		pf.file.write(bytes.data(), bytes.size());
+		pf.commit();
+	}
+} // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/Emu/GUI/modern/ModernTelemetry.h
+++ b/rpcs3/Emu/GUI/modern/ModernTelemetry.h
@@ -1,0 +1,20 @@
+#pragma once
+#ifdef ENABLE_MODERN_MANAGER
+
+#include <QString>
+
+namespace rpcs3::ui
+{
+	class ModernTelemetry
+	{
+	public:
+		static ModernTelemetry& instance();
+		void logEvent(const QString& name, const QString& reason = {});
+
+	private:
+		ModernTelemetry();
+		QString m_path;
+	};
+} // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -169,12 +169,16 @@ add_library(rpcs3_ui STATIC
 
 if(ENABLE_MODERN_MANAGER)
     target_sources(rpcs3_ui PRIVATE
-        ../Emu/GUI/modern/ModernManagerWindow.cpp
-        ../Emu/GUI/modern/ModernManagerWindow.h
-        ../Emu/GUI/modern/ModernLibraryModel.cpp
-        ../Emu/GUI/modern/ModernLibraryModel.h
-        ../Emu/GUI/modern/resources/modern_manager.qrc
-    )
+    ../Emu/GUI/modern/ModernManagerWindow.cpp
+    ../Emu/GUI/modern/ModernManagerWindow.h
+    ../Emu/GUI/modern/ModernLibraryModel.cpp
+    ../Emu/GUI/modern/ModernLibraryModel.h
+    ../Emu/GUI/modern/LibraryMetadataStore.cpp
+    ../Emu/GUI/modern/LibraryMetadataStore.h
+    ../Emu/GUI/modern/ModernTelemetry.cpp
+    ../Emu/GUI/modern/ModernTelemetry.h
+    ../Emu/GUI/modern/resources/modern_manager.qrc
+)
     target_compile_definitions(rpcs3_ui PRIVATE ENABLE_MODERN_MANAGER)
 endif()
 


### PR DESCRIPTION
## Summary
- add cross-platform CI workflow building Modern Manager with Qt
- prevent Modern Manager crashes with better guards and UI states
- persist window settings and log Modern Manager events locally
- document Modern Game Manager beta usage

## Testing
- `cmake -S . -B build -DENABLE_MODERN_MANAGER=ON` *(fails: source directories missing)*

------