### PR TITLE
feat(modern): console Home screen + controller-style navigation (phase 1), console startup option

### DIFF
--- a/rpcs3/Emu/GUI/modern/BigTile.cpp
+++ b/rpcs3/Emu/GUI/modern/BigTile.cpp
@@ -1,0 +1,90 @@
+#ifdef ENABLE_MODERN_MANAGER
+
+#include "BigTile.h"
+
+#include <QVBoxLayout>
+#include <QLabel>
+#include <QKeyEvent>
+#include <QPainter>
+
+namespace rpcs3::ui
+{
+	BigTile::BigTile(QWidget* parent)
+		: QWidget(parent)
+	{
+		setFocusPolicy(Qt::StrongFocus);
+		auto* layout = new QVBoxLayout(this);
+		layout->setContentsMargins(4, 4, 4, 4);
+		layout->setSpacing(4);
+		layout->addStretch();
+		m_image = new QLabel(this);
+		m_image->setAlignment(Qt::AlignCenter);
+		layout->addWidget(m_image);
+		m_title = new QLabel(this);
+		m_title->setAlignment(Qt::AlignCenter);
+		layout->addWidget(m_title);
+	}
+
+	void BigTile::setPixmap(const QPixmap& pix)
+	{
+		m_image->setPixmap(pix);
+	}
+
+	void BigTile::setTitle(const QString& title)
+	{
+		m_title->setText(title);
+	}
+
+	void BigTile::setSelected(bool selected)
+	{
+		if (m_selected == selected)
+			return;
+		m_selected = selected;
+		update();
+	}
+
+	void BigTile::paintEvent(QPaintEvent* ev)
+	{
+		QWidget::paintEvent(ev);
+		if (m_selected)
+		{
+			QPainter p(this);
+			p.setPen(QPen(Qt::yellow, 2));
+			p.drawRect(rect().adjusted(1, 1, -1, -1));
+		}
+	}
+
+	void BigTile::keyPressEvent(QKeyEvent* event)
+	{
+		if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter || event->key() == Qt::Key_Space)
+		{
+			Q_EMIT activated();
+			event->accept();
+			return;
+		}
+		QWidget::keyPressEvent(event);
+	}
+
+	void BigTile::focusInEvent(QFocusEvent* event)
+	{
+		setSelected(true);
+		QWidget::focusInEvent(event);
+	}
+
+	void BigTile::focusOutEvent(QFocusEvent* event)
+	{
+		setSelected(false);
+		QWidget::focusOutEvent(event);
+	}
+
+	void BigTile::mouseDoubleClickEvent(QMouseEvent* event)
+	{
+		if (event->button() == Qt::LeftButton)
+		{
+			Q_EMIT activated();
+		}
+		QWidget::mouseDoubleClickEvent(event);
+	}
+} // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/Emu/GUI/modern/BigTile.h
+++ b/rpcs3/Emu/GUI/modern/BigTile.h
@@ -1,0 +1,39 @@
+#pragma once
+#ifdef ENABLE_MODERN_MANAGER
+
+#include <QWidget>
+#include <QPixmap>
+
+class QLabel;
+class QPropertyAnimation;
+
+namespace rpcs3::ui
+{
+	class BigTile : public QWidget
+	{
+		Q_OBJECT
+	public:
+		explicit BigTile(QWidget* parent = nullptr);
+
+		void setPixmap(const QPixmap& pix);
+		void setTitle(const QString& title);
+		void setSelected(bool selected);
+
+	Q_SIGNALS:
+		void activated();
+
+	protected:
+		void paintEvent(QPaintEvent* event) override;
+		void keyPressEvent(QKeyEvent* event) override;
+		void focusInEvent(QFocusEvent* event) override;
+		void focusOutEvent(QFocusEvent* event) override;
+		void mouseDoubleClickEvent(QMouseEvent* event) override;
+
+	private:
+		QLabel* m_image = nullptr;
+		QLabel* m_title = nullptr;
+		bool m_selected = false;
+	};
+} // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/Emu/GUI/modern/FocusNav.cpp
+++ b/rpcs3/Emu/GUI/modern/FocusNav.cpp
@@ -1,0 +1,112 @@
+#ifdef ENABLE_MODERN_MANAGER
+
+#include "FocusNav.h"
+
+#include <QKeyEvent>
+#include <QWidget>
+#include <QApplication>
+
+namespace rpcs3::ui
+{
+	FocusNav::FocusNav(QWidget* root)
+		: QObject(root), m_root(root)
+	{
+		setPolicies(root);
+		root->installEventFilter(this);
+	}
+
+	void FocusNav::install(QWidget* root)
+	{
+		new FocusNav(root);
+	}
+
+	void FocusNav::setPolicies(QWidget* w)
+	{
+		w->setFocusPolicy(Qt::StrongFocus);
+		for (auto* child : w->findChildren<QWidget*>(QString(), Qt::FindDirectChildrenOnly))
+		{
+			setPolicies(child);
+		}
+	}
+
+	QWidget* FocusNav::nextWidget(QWidget* current, Qt::Key key) const
+	{
+		if (!m_root)
+			return nullptr;
+		const QRect cur = current->geometry().translated(current->mapTo(m_root, QPoint()));
+		QWidget* best = nullptr;
+		int best_dist = std::numeric_limits<int>::max();
+
+		const auto widgets = m_root->findChildren<QWidget*>();
+		for (QWidget* w : widgets)
+		{
+			if (!w->isVisible() || w->focusPolicy() == Qt::NoFocus || w == current)
+				continue;
+			QRect r = w->geometry().translated(w->mapTo(m_root, QPoint()));
+			QPoint delta = r.center() - cur.center();
+			switch (key)
+			{
+			case Qt::Key_Left:
+				if (delta.x() >= 0)
+					continue;
+				break;
+			case Qt::Key_Right:
+				if (delta.x() <= 0)
+					continue;
+				break;
+			case Qt::Key_Up:
+				if (delta.y() >= 0)
+					continue;
+				break;
+			case Qt::Key_Down:
+				if (delta.y() <= 0)
+					continue;
+				break;
+			default: break;
+			}
+			int dist = delta.x() * delta.x() + delta.y() * delta.y();
+			if (dist < best_dist)
+			{
+				best_dist = dist;
+				best = w;
+			}
+		}
+		return best;
+	}
+
+	bool FocusNav::eventFilter(QObject* obj, QEvent* ev)
+	{
+		if (ev->type() == QEvent::KeyPress)
+		{
+			QKeyEvent* ke = static_cast<QKeyEvent*>(ev);
+			QWidget* fw = m_root->focusWidget();
+			if (!fw)
+				fw = m_root;
+			switch (ke->key())
+			{
+			case Qt::Key_Left:
+			case Qt::Key_Right:
+			case Qt::Key_Up:
+			case Qt::Key_Down:
+			{
+				if (QWidget* next = nextWidget(fw, static_cast<Qt::Key>(ke->key())))
+				{
+					next->setFocus(Qt::OtherFocusReason);
+					return true;
+				}
+				break;
+			}
+			case Qt::Key_Return:
+			case Qt::Key_Enter:
+			case Qt::Key_Space:
+				Q_EMIT activated();
+				break;
+			default:
+				break;
+			}
+		}
+		return QObject::eventFilter(obj, ev);
+	}
+} // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/Emu/GUI/modern/FocusNav.h
+++ b/rpcs3/Emu/GUI/modern/FocusNav.h
@@ -1,0 +1,29 @@
+#pragma once
+#ifdef ENABLE_MODERN_MANAGER
+
+#include <QObject>
+#include <QWidget>
+
+namespace rpcs3::ui
+{
+	class FocusNav : public QObject
+	{
+		Q_OBJECT
+	public:
+		static void install(QWidget* root);
+
+	Q_SIGNALS:
+		void activated();
+
+	protected:
+		bool eventFilter(QObject* obj, QEvent* ev) override;
+
+	private:
+		explicit FocusNav(QWidget* root);
+		QWidget* m_root = nullptr;
+		QWidget* nextWidget(QWidget* current, Qt::Key key) const;
+		static void setPolicies(QWidget* w);
+	};
+} // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/Emu/GUI/modern/HomeView.cpp
+++ b/rpcs3/Emu/GUI/modern/HomeView.cpp
@@ -1,0 +1,112 @@
+#ifdef ENABLE_MODERN_MANAGER
+
+#include "HomeView.h"
+#include "BigTile.h"
+#include "ModernLibraryModel.h"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+
+namespace rpcs3::ui
+{
+	HomeView::HomeView(QWidget* parent)
+		: QWidget(parent)
+	{
+		auto* layout = new QVBoxLayout(this);
+		layout->setContentsMargins(8, 8, 8, 8);
+		layout->setSpacing(8);
+
+		m_continue = new BigTile(this);
+		m_continue->setTitle(tr("Continue"));
+		layout->addWidget(m_continue);
+		connect(m_continue, &BigTile::activated, [this]()
+			{
+				if (!m_model)
+					return;
+				// use first entry as last played
+				if (m_model->rowCount() > 0)
+				{
+					auto entry = m_model->entryAt(m_model->index(0, 0));
+					Q_EMIT playRequested(entry.path);
+				}
+			});
+
+		m_recentsWidget = new QWidget(this);
+		auto* recentsLayout = new QHBoxLayout(m_recentsWidget);
+		recentsLayout->setContentsMargins(0, 0, 0, 0);
+		recentsLayout->setSpacing(8);
+		layout->addWidget(m_recentsWidget);
+
+		QLabel* friends = new QLabel(tr("Friends Online: 0"), this);
+		layout->addWidget(friends);
+
+		m_actionsWidget = new QWidget(this);
+		auto* actionsLayout = new QHBoxLayout(m_actionsWidget);
+		actionsLayout->setContentsMargins(0, 0, 0, 0);
+		actionsLayout->setSpacing(8);
+		layout->addWidget(m_actionsWidget);
+
+		// Quick actions
+		BigTile* installPkg = new BigTile(this);
+		installPkg->setTitle(tr("Install .pkg"));
+		connect(installPkg, &BigTile::activated, this, &HomeView::installPkgRequested);
+		actionsLayout->addWidget(installPkg);
+
+		BigTile* addFolder = new BigTile(this);
+		addFolder->setTitle(tr("Add Disc Folder"));
+		connect(addFolder, &BigTile::activated, this, &HomeView::addDiscFolderRequested);
+		actionsLayout->addWidget(addFolder);
+
+		BigTile* settings = new BigTile(this);
+		settings->setTitle(tr("Settings"));
+		connect(settings, &BigTile::activated, this, &HomeView::settingsRequested);
+		actionsLayout->addWidget(settings);
+
+		BigTile* online = new BigTile(this);
+		online->setTitle(tr("Online"));
+		connect(online, &BigTile::activated, this, &HomeView::onlineRequested);
+		actionsLayout->addWidget(online);
+	}
+
+	void HomeView::setModel(ModernLibraryModel* m)
+	{
+		m_model = m;
+		rebuild();
+	}
+
+	void HomeView::setSocialService(ISocialService* s)
+	{
+		m_social = s;
+		Q_UNUSED(m_social);
+	}
+
+	void HomeView::rebuild()
+	{
+		if (!m_model)
+			return;
+		// Clear recents
+		delete m_recentsWidget;
+		m_recentsWidget = new QWidget(this);
+		auto* recentsLayout = new QHBoxLayout(m_recentsWidget);
+		recentsLayout->setContentsMargins(0, 0, 0, 0);
+		recentsLayout->setSpacing(8);
+		layout()->addWidget(m_recentsWidget);
+
+		const int count = std::min(12, m_model->rowCount());
+		for (int i = 0; i < count; ++i)
+		{
+			auto entry = m_model->entryAt(m_model->index(i, 0));
+			BigTile* tile = new BigTile(this);
+			tile->setTitle(entry.name);
+			tile->setPixmap(entry.icon);
+			connect(tile, &BigTile::activated, this, [this, entry]()
+				{
+					Q_EMIT openDetailsRequested(entry.title_id);
+				});
+			recentsLayout->addWidget(tile);
+		}
+	}
+} // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/Emu/GUI/modern/HomeView.h
+++ b/rpcs3/Emu/GUI/modern/HomeView.h
@@ -1,0 +1,40 @@
+#pragma once
+#ifdef ENABLE_MODERN_MANAGER
+
+#include <QWidget>
+#include <QVector>
+
+namespace rpcs3::ui
+{
+	class ModernLibraryModel;
+	class ISocialService;
+	class BigTile;
+
+	class HomeView : public QWidget
+	{
+		Q_OBJECT
+	public:
+		explicit HomeView(QWidget* parent = nullptr);
+
+		void setModel(ModernLibraryModel* m);
+		void setSocialService(ISocialService* s);
+
+	Q_SIGNALS:
+		void playRequested(QString path);
+		void openDetailsRequested(QString title_id);
+		void installPkgRequested();
+		void addDiscFolderRequested();
+		void settingsRequested();
+		void onlineRequested();
+
+	private:
+		void rebuild();
+		ModernLibraryModel* m_model = nullptr;
+		ISocialService* m_social = nullptr;
+		BigTile* m_continue = nullptr;
+		QWidget* m_recentsWidget = nullptr;
+		QWidget* m_actionsWidget = nullptr;
+	};
+} // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/Emu/GUI/modern/ModernManagerWindow.cpp
+++ b/rpcs3/Emu/GUI/modern/ModernManagerWindow.cpp
@@ -1,6 +1,10 @@
 #ifdef ENABLE_MODERN_MANAGER
 
 #include "ModernManagerWindow.h"
+#include "HomeView.h"
+#include "FocusNav.h"
+#include "ModernSettingsPanel.h"
+#include "ModernTelemetry.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -9,14 +13,15 @@
 #include <QMessageBox>
 #include <QDesktopServices>
 #include <QUrl>
-#include <memory>
+#include <QShortcut>
+#include <QApplication>
+#include <QKeyEvent>
 
 #include "Emu/System.h"
 #include "Utilities/File.h"
 #include "util/logs.hpp"
 #include "rpcs3qt/pad_settings_dialog.h"
 #include "rpcs3qt/gui_settings.h"
-#include "ModernTelemetry.h"
 
 LOG_CHANNEL(modern_manager_log, "ModernManager");
 
@@ -25,10 +30,52 @@ namespace rpcs3::ui
 	ModernManagerWindow::ModernManagerWindow(QWidget* parent)
 		: QMainWindow(parent)
 	{
+		m_settings = std::make_shared<gui_settings>();
+		if (m_settings->GetValue("modern", "large_text", false).toBool())
+		{
+			QFont f = QApplication::font();
+			f.setPointSize(f.pointSize() + 2);
+			QApplication::setFont(f);
+		}
+
+		navHome = new QPushButton(tr("Home"), this);
+		navLibrary = new QPushButton(tr("Library"), this);
+		navHome->setCheckable(true);
+		navLibrary->setCheckable(true);
+		navHome->setFocusPolicy(Qt::StrongFocus);
+		navLibrary->setFocusPolicy(Qt::StrongFocus);
+		connect(navHome, &QPushButton::clicked, this, &ModernManagerWindow::showHome);
+		connect(navLibrary, &QPushButton::clicked, this, &ModernManagerWindow::showLibrary);
+
+		m_pages = new QStackedWidget(this);
+
+		// Models
+		m_model = new ModernLibraryModel(this);
+
+		// Home page
+		m_home = new HomeView(this);
+		m_home->setModel(m_model);
+		m_pages->addWidget(m_home);
+		connect(m_home, &HomeView::playRequested, this, &ModernManagerWindow::requestBootGame);
+		connect(m_home, &HomeView::openDetailsRequested, this, [this](const QString& id)
+			{
+				showLibrary();
+				for (int row = 0; row < m_model->rowCount(); ++row)
+				{
+					auto entry = m_model->entryAt(m_model->index(row, 0));
+					if (entry.title_id == id)
+					{
+						gameGrid->setCurrentIndex(m_model->index(row, 0));
+						break;
+					}
+				}
+			});
+
+		// Library page
+
 		searchBar = new QLineEdit(this);
 		btnSettings = new QPushButton(tr("Settings"), this);
 		lblFirmwareStatus = new QLabel(tr("FW Unknown"), this);
-
 		btnAddGame = new QPushButton(tr("Add Game"), this);
 		btnAddGame->setToolTip(tr("Add a new game to the library"));
 		btnOptimize = new QPushButton(tr("Optimize"), this);
@@ -45,6 +92,8 @@ namespace rpcs3::ui
 		gameGrid->setWrapping(true);
 		gameGrid->setResizeMode(QListView::Adjust);
 		gameGrid->setIconSize({96, 96});
+		gameGrid->setFocusPolicy(Qt::StrongFocus);
+		gameGrid->setModel(m_model);
 
 		lblGameTitle = new QLabel(this);
 		lblLastPlayed = new QLabel(this);
@@ -53,19 +102,8 @@ namespace rpcs3::ui
 		btnPlay = new QPushButton(tr("Play"), this);
 		btnPlay->setToolTip(tr("Boot selected game"));
 
-		m_settings = std::make_shared<gui_settings>();
-		m_show_favorites_only = m_settings->GetValue("ui/modern_manager", "show_favorites_only", false).toBool();
-		const QByteArray geom = m_settings->GetValue("ui/modern_manager", "window_geometry", QByteArray()).toByteArray();
-		if (!geom.isEmpty())
-		{
-			restoreGeometry(geom);
-		}
-
-		m_model = new ModernLibraryModel(this);
-		gameGrid->setModel(m_model);
-
-		auto* central = new QWidget(this);
-		auto* mainLayout = new QVBoxLayout(central);
+		m_libraryPage = new QWidget(this);
+		auto* mainLayout = new QVBoxLayout(m_libraryPage);
 		mainLayout->setContentsMargins(4, 4, 4, 4);
 
 		auto* topLayout = new QHBoxLayout();
@@ -99,7 +137,16 @@ namespace rpcs3::ui
 		detailsLayout->addWidget(btnPlay);
 		mainLayout->addLayout(detailsLayout);
 
-		setCentralWidget(central);
+		m_pages->addWidget(m_libraryPage);
+
+		auto* root = new QWidget(this);
+		auto* rootLayout = new QVBoxLayout(root);
+		auto* navLayout = new QHBoxLayout();
+		navLayout->addWidget(navHome);
+		navLayout->addWidget(navLibrary);
+		rootLayout->addLayout(navLayout);
+		rootLayout->addWidget(m_pages);
+		setCentralWidget(root);
 
 		connect(searchBar, &QLineEdit::textChanged, m_model, &ModernLibraryModel::setFilterString);
 		connect(btnAddGame, &QPushButton::clicked, this, &ModernManagerWindow::slotAddGame);
@@ -109,7 +156,20 @@ namespace rpcs3::ui
 		connect(btnUpdateAll, &QPushButton::clicked, this, &ModernManagerWindow::slotUpdateAll);
 		connect(gameGrid->selectionModel(), &QItemSelectionModel::selectionChanged, this, &ModernManagerWindow::updateDetailsPane);
 		connect(btnPlay, &QPushButton::clicked, this, &ModernManagerWindow::slotPlayGame);
+		connect(btnSettings, &QPushButton::clicked, this, &ModernManagerWindow::openSettings);
 
+		connect(m_home, &HomeView::installPkgRequested, this, &ModernManagerWindow::slotAddGame);
+		connect(m_home, &HomeView::addDiscFolderRequested, this, &ModernManagerWindow::slotAddGame);
+		connect(m_home, &HomeView::settingsRequested, this, &ModernManagerWindow::openSettings);
+
+		new QShortcut(QKeySequence(Qt::Key_F11), this, [this]()
+			{
+				isFullScreen() ? showNormal() : showFullScreen();
+			});
+
+		FocusNav::install(m_home);
+		FocusNav::install(m_libraryPage);
+		showHome();
 		updateActions();
 	}
 
@@ -118,34 +178,20 @@ namespace rpcs3::ui
 		if (m_settings)
 		{
 			m_settings->SetValue("ui/modern_manager", "window_geometry", saveGeometry());
-			m_settings->SetValue("ui/modern_manager", "show_favorites_only", m_show_favorites_only);
 		}
 	}
 
-	ModernLibraryModel::GameEntry ModernManagerWindow::currentEntry() const
+	void ModernManagerWindow::requestBootGame(const QString& path)
 	{
-		return m_model->entryAt(gameGrid->currentIndex());
-	}
-
-	void ModernManagerWindow::slotAddGame()
-	{
-		try
+		if (path.isEmpty())
+			return;
+		ModernTelemetry::instance().logEvent("last_launched_from", "home");
+		ModernTelemetry::instance().logEvent("play_start");
+		const auto res = Emu.BootGame(path.toStdString(), std::string{}, true);
+		if (res != game_boot_result::no_errors)
 		{
-			const QString dir = QFileDialog::getExistingDirectory(this, tr("Select Game Folder"));
-			if (dir.isEmpty())
-			{
-				return;
-			}
-
-			if (Emu.AddGamesFromDir(dir.toStdString()) > 0)
-			{
-				m_model->refresh();
-			}
-		}
-		catch (const std::exception& e)
-		{
-			modern_manager_log.error("AddGame failed: %s", e.what());
-			QMessageBox box(QMessageBox::Critical, tr("Error"), tr("Failed to add game."), QMessageBox::Ok, this);
+			modern_manager_log.error("Failed to boot %s", path.toStdString());
+			QMessageBox box(QMessageBox::Critical, tr("Error"), tr("Failed to start game."), QMessageBox::Ok, this);
 			auto* openLogs = box.addButton(tr("Open logs"), QMessageBox::ActionRole);
 			box.exec();
 			if (box.clickedButton() == openLogs)
@@ -155,31 +201,21 @@ namespace rpcs3::ui
 		}
 	}
 
+	void ModernManagerWindow::slotAddGame()
+	{
+		const QString dir = QFileDialog::getExistingDirectory(this, tr("Select Game Folder"));
+		if (dir.isEmpty())
+			return;
+		if (Emu.AddGamesFromDir(dir.toStdString()) > 0)
+			m_model->refresh();
+	}
+
 	void ModernManagerWindow::slotOptimize()
-	{
-		const auto entry = currentEntry();
-		if (entry.path.isEmpty())
-		{
-			return;
-		}
-
-		modern_manager_log.notice("Optimize requested for %s", entry.title_id.toStdString());
-		ModernTelemetry::instance().logEvent("optimize_applied");
+	{ /* stub */
 	}
-
 	void ModernManagerWindow::slotPrebuildShaders()
-	{
-		const auto entry = currentEntry();
-		if (entry.path.isEmpty())
-		{
-			return;
-		}
-
-		modern_manager_log.notice("Prebuild shaders requested for %s", entry.title_id.toStdString());
-		ModernTelemetry::instance().logEvent("prebuild_start");
-		ModernTelemetry::instance().logEvent("prebuild_finish");
+	{ /* stub */
 	}
-
 	void ModernManagerWindow::slotControllerSetup()
 	{
 		auto settings = std::make_shared<gui_settings>();
@@ -189,7 +225,6 @@ namespace rpcs3::ui
 
 	void ModernManagerWindow::slotUpdateAll()
 	{
-		modern_manager_log.notice("Update all requested");
 		m_model->refresh();
 	}
 
@@ -197,27 +232,17 @@ namespace rpcs3::ui
 	{
 		const auto entry = currentEntry();
 		if (entry.path.isEmpty())
-		{
 			return;
-		}
-
 		ModernTelemetry::instance().logEvent("play_start");
 		const auto res = Emu.BootGame(entry.path.toStdString(), entry.title_id.toStdString(), true);
 		if (res != game_boot_result::no_errors)
 		{
 			modern_manager_log.error("Failed to boot %s", entry.title_id.toStdString());
-			ModernTelemetry::instance().logEvent("play_stop", QStringLiteral("boot_failed"));
 			QMessageBox box(QMessageBox::Critical, tr("Error"), tr("Failed to start game."), QMessageBox::Ok, this);
 			auto* openLogs = box.addButton(tr("Open logs"), QMessageBox::ActionRole);
 			box.exec();
 			if (box.clickedButton() == openLogs)
-			{
 				QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(fs::get_log_dir())));
-			}
-		}
-		else
-		{
-			ModernTelemetry::instance().logEvent("play_stop");
 		}
 	}
 
@@ -237,6 +262,44 @@ namespace rpcs3::ui
 		btnOptimize->setEnabled(has_game);
 		btnPrebuildShaders->setEnabled(has_game);
 		btnPlay->setEnabled(has_game);
+	}
+
+	void ModernManagerWindow::showHome()
+	{
+		m_pages->setCurrentWidget(m_home);
+		navHome->setChecked(true);
+		navLibrary->setChecked(false);
+	}
+
+	void ModernManagerWindow::showLibrary()
+	{
+		m_pages->setCurrentWidget(m_libraryPage);
+		navHome->setChecked(false);
+		navLibrary->setChecked(true);
+	}
+
+	void ModernManagerWindow::openSettings()
+	{
+		if (!m_settings_panel)
+		{
+			m_settings_panel = new ModernSettingsPanel(m_settings, this);
+		}
+		m_settings_panel->exec();
+	}
+
+	ModernLibraryModel::GameEntry ModernManagerWindow::currentEntry() const
+	{
+		return m_model->entryAt(gameGrid->currentIndex());
+	}
+
+	void ModernManagerWindow::keyPressEvent(QKeyEvent* event)
+	{
+		if ((event->key() == Qt::Key_Escape || event->key() == Qt::Key_Backspace) && m_pages->currentWidget() == m_libraryPage)
+		{
+			showHome();
+			return;
+		}
+		QMainWindow::keyPressEvent(event);
 	}
 } // namespace rpcs3::ui
 

--- a/rpcs3/Emu/GUI/modern/ModernManagerWindow.h
+++ b/rpcs3/Emu/GUI/modern/ModernManagerWindow.h
@@ -7,12 +7,18 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QListView>
+#include <QStackedWidget>
 #include <memory>
 
 #include "ModernLibraryModel.h"
 #include "LibraryMetadataStore.h"
 
 class gui_settings;
+class ModernSettingsPanel;
+namespace rpcs3::ui
+{
+	class HomeView;
+}
 
 namespace rpcs3::ui
 {
@@ -24,6 +30,9 @@ namespace rpcs3::ui
 		explicit ModernManagerWindow(QWidget* parent = nullptr);
 		~ModernManagerWindow() override;
 
+	public Q_SLOTS:
+		void requestBootGame(const QString& path);
+
 	private Q_SLOTS:
 		void slotAddGame();
 		void slotOptimize();
@@ -33,6 +42,9 @@ namespace rpcs3::ui
 		void slotPlayGame();
 		void updateDetailsPane();
 		void updateActions();
+		void showHome();
+		void showLibrary();
+		void openSettings();
 
 	private:
 		ModernLibraryModel::GameEntry currentEntry() const;
@@ -41,6 +53,10 @@ namespace rpcs3::ui
 		std::shared_ptr<gui_settings> m_settings;
 		LibraryMetadataStore m_metadata;
 		bool m_show_favorites_only = false;
+
+		QStackedWidget* m_pages = nullptr;
+		HomeView* m_home = nullptr;
+		QWidget* m_libraryPage = nullptr;
 
 		QLineEdit* searchBar = nullptr;
 		QPushButton* btnSettings = nullptr;
@@ -56,6 +72,14 @@ namespace rpcs3::ui
 		QLabel* lblHoursPlayed = nullptr;
 		QLabel* lblStatus = nullptr;
 		QPushButton* btnPlay = nullptr;
+
+		QPushButton* navHome = nullptr;
+		QPushButton* navLibrary = nullptr;
+
+		ModernSettingsPanel* m_settings_panel = nullptr;
+
+	protected:
+		void keyPressEvent(QKeyEvent* event) override;
 	};
 } // namespace rpcs3::ui
 

--- a/rpcs3/Emu/GUI/modern/ModernSettingsPanel.cpp
+++ b/rpcs3/Emu/GUI/modern/ModernSettingsPanel.cpp
@@ -1,0 +1,43 @@
+#ifdef ENABLE_MODERN_MANAGER
+
+#include "ModernSettingsPanel.h"
+#include "rpcs3qt/gui_settings.h"
+
+#include <QVBoxLayout>
+#include <QCheckBox>
+#include <QPushButton>
+
+namespace rpcs3::ui
+{
+	ModernSettingsPanel::ModernSettingsPanel(std::shared_ptr<gui_settings> settings, QWidget* parent)
+		: QDialog(parent), m_settings(std::move(settings))
+	{
+		setWindowTitle(tr("Settings"));
+		auto* layout = new QVBoxLayout(this);
+
+		m_start_console = new QCheckBox(tr("Start in Console Mode"), this);
+		m_start_console->setChecked(m_settings->GetValue("modern", "start_console_mode", false).toBool());
+		layout->addWidget(m_start_console);
+
+		m_large_text = new QCheckBox(tr("Large Text mode"), this);
+		m_large_text->setChecked(m_settings->GetValue("modern", "large_text", false).toBool());
+		layout->addWidget(m_large_text);
+
+		QPushButton* online = new QPushButton(tr("Online Settings..."), this);
+		layout->addWidget(online);
+		connect(online, &QPushButton::clicked, this, []() { /* placeholder */ });
+
+		auto* ok = new QPushButton(tr("OK"), this);
+		layout->addWidget(ok);
+		connect(ok, &QPushButton::clicked, this, &ModernSettingsPanel::save);
+	}
+
+	void ModernSettingsPanel::save()
+	{
+		m_settings->SetValue("modern", "start_console_mode", m_start_console->isChecked());
+		m_settings->SetValue("modern", "large_text", m_large_text->isChecked());
+		accept();
+	}
+} // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/Emu/GUI/modern/ModernSettingsPanel.h
+++ b/rpcs3/Emu/GUI/modern/ModernSettingsPanel.h
@@ -1,0 +1,29 @@
+#pragma once
+#ifdef ENABLE_MODERN_MANAGER
+
+#include <QDialog>
+#include <memory>
+
+class QCheckBox;
+class QPushButton;
+class gui_settings;
+
+namespace rpcs3::ui
+{
+	class ModernSettingsPanel : public QDialog
+	{
+		Q_OBJECT
+	public:
+		explicit ModernSettingsPanel(std::shared_ptr<gui_settings> settings, QWidget* parent = nullptr);
+
+	private Q_SLOTS:
+		void save();
+
+	private:
+		std::shared_ptr<gui_settings> m_settings;
+		QCheckBox* m_start_console = nullptr;
+		QCheckBox* m_large_text = nullptr;
+	};
+} // namespace rpcs3::ui
+
+#endif // ENABLE_MODERN_MANAGER

--- a/rpcs3/Emu/GUI/modern/resources/add_folder.svg
+++ b/rpcs3/Emu/GUI/modern/resources/add_folder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"></svg>

--- a/rpcs3/Emu/GUI/modern/resources/console.qrc
+++ b/rpcs3/Emu/GUI/modern/resources/console.qrc
@@ -1,0 +1,12 @@
+<RCC>
+    <qresource prefix="/console">
+        <file>home.svg</file>
+        <file>library.svg</file>
+        <file>friends.svg</file>
+        <file>lobby.svg</file>
+        <file>settings.svg</file>
+        <file>continue.svg</file>
+        <file>install_pkg.svg</file>
+        <file>add_folder.svg</file>
+    </qresource>
+</RCC>

--- a/rpcs3/Emu/GUI/modern/resources/continue.svg
+++ b/rpcs3/Emu/GUI/modern/resources/continue.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"></svg>

--- a/rpcs3/Emu/GUI/modern/resources/friends.svg
+++ b/rpcs3/Emu/GUI/modern/resources/friends.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"></svg>

--- a/rpcs3/Emu/GUI/modern/resources/home.svg
+++ b/rpcs3/Emu/GUI/modern/resources/home.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"></svg>

--- a/rpcs3/Emu/GUI/modern/resources/install_pkg.svg
+++ b/rpcs3/Emu/GUI/modern/resources/install_pkg.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"></svg>

--- a/rpcs3/Emu/GUI/modern/resources/library.svg
+++ b/rpcs3/Emu/GUI/modern/resources/library.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"></svg>

--- a/rpcs3/Emu/GUI/modern/resources/lobby.svg
+++ b/rpcs3/Emu/GUI/modern/resources/lobby.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"></svg>

--- a/rpcs3/Emu/GUI/modern/resources/settings.svg
+++ b/rpcs3/Emu/GUI/modern/resources/settings.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"></svg>

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -177,7 +177,16 @@ if(ENABLE_MODERN_MANAGER)
     ../Emu/GUI/modern/LibraryMetadataStore.h
     ../Emu/GUI/modern/ModernTelemetry.cpp
     ../Emu/GUI/modern/ModernTelemetry.h
+    ../Emu/GUI/modern/HomeView.cpp
+    ../Emu/GUI/modern/HomeView.h
+    ../Emu/GUI/modern/FocusNav.cpp
+    ../Emu/GUI/modern/FocusNav.h
+    ../Emu/GUI/modern/BigTile.cpp
+    ../Emu/GUI/modern/BigTile.h
+    ../Emu/GUI/modern/ModernSettingsPanel.cpp
+    ../Emu/GUI/modern/ModernSettingsPanel.h
     ../Emu/GUI/modern/resources/modern_manager.qrc
+    ../Emu/GUI/modern/resources/console.qrc
 )
     target_compile_definitions(rpcs3_ui PRIVATE ENABLE_MODERN_MANAGER)
 endif()

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -198,6 +198,17 @@ bool main_window::Init([[maybe_unused]] bool with_cli_boot)
 	CreateDockWindows();
 	CreateConnects();
 
+#ifdef ENABLE_MODERN_MANAGER
+	if (m_gui_settings->GetValue("modern", "start_console_mode", false).toBool())
+	{
+		if (!m_modern_manager_window)
+		{
+			m_modern_manager_window = std::make_unique<rpcs3::ui::ModernManagerWindow>(this);
+		}
+		m_modern_manager_window->showFullScreen();
+	}
+#endif
+
 	setMinimumSize(350, minimumSizeHint().height()); // seems fine on win 10
 	setWindowTitle(QString::fromStdString("RPCS3 " + rpcs3::get_verbose_version()));
 


### PR DESCRIPTION
## Summary
- Add console-oriented HomeView with continue tile, recents row and quick actions
- Introduce FocusNav, BigTile, and ModernSettingsPanel widgets for keyboard navigation and settings
- Integrate Home and Library pages in ModernManagerWindow and support startup in console mode

## Testing
- `cmake -S . -B build` *(fails: add_subdirectory given source "zstd/build/cmake" which is not an existing directory)*

------