### PR TITLE
Add JIT baking module scaffold

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ project(rpcs3 LANGUAGES C CXX)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+if(NOT EXISTS "${CMAKE_SOURCE_DIR}/jit_baking/CMakeLists.txt")
+    message(FATAL_ERROR "Missing LLVM JIT Baking module directory at: ${CMAKE_SOURCE_DIR}/jit_baking")
+endif()
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11)
         message(FATAL_ERROR "RPCS3 requires at least gcc-11.")
@@ -188,6 +192,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${PROJECT_BINARY_DIR}/bin")
 if(BUILD_RPCS3_TESTS)
     enable_testing()
 endif()
+add_subdirectory(jit_baking)
 add_subdirectory(rpcs3)
 
 set_directory_properties(PROPERTIES VS_STARTUP_PROJECT rpcs3)

--- a/jit_baking/CMakeLists.txt
+++ b/jit_baking/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(jit_baking STATIC
+    jit_baking.cpp
+    jit_baking.h)
+
+target_include_directories(jit_baking PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+

--- a/jit_baking/jit_baking.cpp
+++ b/jit_baking/jit_baking.cpp
@@ -1,0 +1,4 @@
+#include "jit_baking.h"
+
+void jit_baking_placeholder() {}
+

--- a/jit_baking/jit_baking.h
+++ b/jit_baking/jit_baking.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void jit_baking_placeholder();
+

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -79,7 +79,8 @@ if (NOT ANDROID)
             3rdparty::zlib
             3rdparty::opencv
             3rdparty::fusion
-            ${ADDITIONAL_LIBS})
+            ${ADDITIONAL_LIBS}
+            jit_baking)
 
     # Unix display manager
     if(X11_FOUND)

--- a/validate_jit_baking.md
+++ b/validate_jit_baking.md
@@ -1,0 +1,12 @@
+# JIT Baking Integration Validation
+
+```bash
+# Ensure jit_baking subdirectory is included
+rg "add_subdirectory\(jit_baking\)" -n CMakeLists.txt
+
+# Verify module CMakeLists exists
+[ -f jit_baking/CMakeLists.txt ] && echo "jit_baking CMakeLists present"
+
+# Check rpcs3_lib links against jit_baking
+rg "target_link_libraries\(rpcs3_lib" -n -A20 rpcs3/CMakeLists.txt | rg "jit_baking" -n
+```


### PR DESCRIPTION
## Summary
- add placeholder JIT baking library and include it in the build
- link jit_baking with rpcs3_lib and ensure configuration fails if module missing
- provide validation script for JIT baking integration

## Testing
- `rg "add_subdirectory\(jit_baking\)" -n CMakeLists.txt`
- `[ -f jit_baking/CMakeLists.txt ] && echo "jit_baking CMakeLists present"`
- `rg "target_link_libraries\(rpcs3_lib" -n -A20 rpcs3/CMakeLists.txt | rg "jit_baking" -n`
- `cmake -S . -B build` *(fails: could not find required 3rdparty directories and OpenGL)*
